### PR TITLE
[Feature] 전체 게시물 목록 조회 구현

### DIFF
--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/postlist/controller/PostListController.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/postlist/controller/PostListController.java
@@ -1,0 +1,21 @@
+package com.team2._3dinterest.domain.yugyeong.postlist.controller;
+
+import com.team2._3dinterest.domain.yugyeong.entity.PostEntity;
+import com.team2._3dinterest.domain.yugyeong.postlist.service.PostListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping( value = "/postlist" )
+@RequiredArgsConstructor
+public class PostListController {
+    private final PostListService postListService;
+
+    @GetMapping
+    public ResponseEntity<List<PostEntity>> postlist() throws IOException {
+        return postListService.postlist(); // 성공, 200 OK 생성
+    }
+}

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/postlist/service/PostListService.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/postlist/service/PostListService.java
@@ -1,0 +1,27 @@
+package com.team2._3dinterest.domain.yugyeong.postlist.service;
+
+import com.team2._3dinterest.domain.yugyeong.entity.PostEntity;
+import com.team2._3dinterest.domain.yugyeong.repository.PostRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostListService {
+    private final PostRepository postRepository;
+
+    @Transactional
+    public ResponseEntity<List<PostEntity>> postlist() {
+        try {
+            List<PostEntity> postEntities = postRepository.findAll();
+            return ResponseEntity.ok(postEntities); // 성공, 200 OK 생성
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("게시물 조회 중 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/PostRepository.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/PostRepository.java
@@ -3,8 +3,10 @@ package com.team2._3dinterest.domain.yugyeong.repository;
 import com.team2._3dinterest.domain.yugyeong.entity.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Integer> {
-    PostEntity findByPostId(int postId);
+    PostEntity findByPostId(int postId);    // download에서 post_table의 postId 조회
+    List<PostEntity> findAll();  // 모든 게시물 조회
 }


### PR DESCRIPTION
전체 게시글 조회를 위한 `postlist` API

GET 요청

post_table의 모든 게시글에 대한 detail을 객체 List로 return한다.

쿼리문: select * from post_table

- PostListController
    
    매개변수: 없음
    
    반환값: PostEntity의 List
    
- PostListService
    
    findAll() 를 통해 PostEntity를 List 형태로 저장함으로써 모든 게시글 정보를 가져온다.
    
    PostEntity의 List를 return 후 성공 시 200 OK를 생성한다.
    
- PostRepository
    
    모든 게시물을 조회하여 List<PostEntity>를 반환하는 findAll() 함수 추가