### PR TITLE
[Feature] 컨트리뷰트 구현

### DIFF
--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/contribute/controller/ContributeListController.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/contribute/controller/ContributeListController.java
@@ -1,0 +1,23 @@
+package com.team2._3dinterest.domain.yugyeong.contribute.controller;
+
+import com.team2._3dinterest.domain.yugyeong.contribute.service.ContributeListService;
+import com.team2._3dinterest.domain.yugyeong.entity.PostEntity;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping( value = "/contribute_list" )
+@RequiredArgsConstructor
+public class ContributeListController {
+    private final ContributeListService contributeListService;
+
+    @GetMapping
+    public ResponseEntity<List<PostEntity>> contribute_list(
+            @Valid @RequestParam(value = "user_id") String user_id) {
+
+        return contributeListService.list(user_id);
+    }
+}

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/contribute/controller/ContributeRecordController.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/contribute/controller/ContributeRecordController.java
@@ -1,0 +1,23 @@
+package com.team2._3dinterest.domain.yugyeong.contribute.controller;
+
+import com.team2._3dinterest.domain.yugyeong.contribute.service.ContributeRecordService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping( value = "/contribute_record" )
+@RequiredArgsConstructor
+public class ContributeRecordController {
+    private final ContributeRecordService contributeRecordService;
+
+    @PostMapping
+    public ResponseEntity<Void> contribute_record(
+            @Valid @RequestParam(value = "post_id") int post_id,
+            @Valid @RequestParam(value = "parent_id") int parent_id ) {
+        contributeRecordService.record(post_id, parent_id);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/contribute/service/ContributeListService.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/contribute/service/ContributeListService.java
@@ -1,0 +1,46 @@
+package com.team2._3dinterest.domain.yugyeong.contribute.service;
+
+import com.team2._3dinterest.domain.yugyeong.entity.DownloadEntity;
+import com.team2._3dinterest.domain.yugyeong.entity.PostEntity;
+import com.team2._3dinterest.domain.yugyeong.repository.DownloadRepository;
+import com.team2._3dinterest.domain.yugyeong.repository.PostRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ContributeListService {
+    private final PostRepository postRepository;
+    private final DownloadRepository downloadRepository;
+
+    @Transactional
+    public ResponseEntity<List<PostEntity>> list(String user_id) {
+        try {
+            // download_history_table에서 user_id를 조회 후 해당하는 DownloadEntity(다운로드 기록)를 가져온다.
+            List<DownloadEntity> downloadEntities = downloadRepository.findByUserId(user_id);
+
+            List<PostEntity> postEntities = new ArrayList<>();
+
+            for (DownloadEntity downloadEntity : downloadEntities) {
+                // download_history_table에서 일치하는 user_id를 찾아 해당 post_id를 모두 가져온다.
+                PostEntity download_post_id = downloadEntity.getPostId();
+
+                // post_table에서 download의 post_id와 일치하는 post_id의 PostEntity를 가져온다.
+                PostEntity postEntity = postRepository.findByPostId(download_post_id.getPostId());
+
+                if (postEntity != null) {
+                    postEntities.add(postEntity);
+                }
+            }
+            return ResponseEntity.ok(postEntities);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("컨트리뷰트 조회 중에 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/contribute/service/ContributeRecordService.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/contribute/service/ContributeRecordService.java
@@ -1,0 +1,38 @@
+package com.team2._3dinterest.domain.yugyeong.contribute.service;
+
+import com.team2._3dinterest.domain.yugyeong.entity.ContributeEntity;
+import com.team2._3dinterest.domain.yugyeong.entity.PostEntity;
+import com.team2._3dinterest.domain.yugyeong.repository.ContributeRepository;
+import com.team2._3dinterest.domain.yugyeong.repository.PostRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ContributeRecordService {
+    private final PostRepository postRepository;
+    private final ContributeRepository contributeRepository;
+
+    @Transactional
+    public ResponseEntity<Void> record(int post_id, int parent_id) {
+        // 부모 엔터티 조회
+        PostEntity parentEntity = postRepository.findByPostId(parent_id);
+
+        if (parentEntity == null) {
+            // 부모 엔터티가 존재하지 않을 경우 예외 처리
+            return ResponseEntity.notFound().build();
+        }
+
+        // ContributeEntity 생성 및 저장
+        ContributeEntity contributeEntity = ContributeEntity.builder()
+                .post_id(post_id)
+                .parent_id(parentEntity)
+                .build();
+
+        contributeRepository.save(contributeEntity);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/controller/DownloadController.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/controller/DownloadController.java
@@ -5,7 +5,6 @@ import com.team2._3dinterest.domain.yugyeong.download.service.DownloadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.io.IOException;
 
 @RestController
 @RequestMapping( value = "/download" )
@@ -16,7 +15,7 @@ public class DownloadController {
     @GetMapping
     public ResponseEntity<byte[]> download(
             @RequestParam(name = "post_id") int post_id,
-            @RequestParam(name = "user_id") String user_id) throws IOException {
+            @RequestParam(name = "user_id") String user_id) {
         RequestDownloadDto requestDownloadDto = new RequestDownloadDto();
         requestDownloadDto.setPost_id(post_id);
         requestDownloadDto.setUser_id(user_id);

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/dto/RequestDownloadDto.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/dto/RequestDownloadDto.java
@@ -14,15 +14,4 @@ public class RequestDownloadDto {
 
     @NotNull(message = "No post_id")
     private int post_id;
-
-    /* Dto -> Entity */
-    public DownloadEntity toEntity() {
-        PostEntity postEntity = new PostEntity();
-        postEntity.setPostId(post_id);
-
-        return DownloadEntity.builder()
-                .user_id(user_id)
-                .postId(postEntity)
-                .build();
-    }
 }

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/dto/RequestDownloadDto.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/dto/RequestDownloadDto.java
@@ -1,7 +1,5 @@
 package com.team2._3dinterest.domain.yugyeong.download.dto;
 
-import com.team2._3dinterest.domain.yugyeong.entity.DownloadEntity;
-import com.team2._3dinterest.domain.yugyeong.entity.PostEntity;
 import lombok.*;
 import javax.validation.constraints.NotNull;
 

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/service/DownloadService.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/service/DownloadService.java
@@ -29,7 +29,7 @@ public class DownloadService {
             if (postEntity != null) {
                 // DownloadEntity 생성 및 저장
                 DownloadEntity downloadEntity = DownloadEntity.builder()
-                        .user_id(requestDownloadDto.getUser_id())
+                        .userId(requestDownloadDto.getUser_id())
                         .postId(postEntity)
                         .build();
 

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/service/DownloadService.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/download/service/DownloadService.java
@@ -36,7 +36,6 @@ public class DownloadService {
                 downloadRepository.save(downloadEntity);
 
                 // S3에서 모델을 다운로드하고 처리하는 로직을 구현
-                // String original_name = postEntity.getOriginal_name();
                 String model_url = postEntity.getModel_url();
 
                 return s3Download.getObject(model_url); // s3에서 다운로드 후 byte 배열 반환

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/entity/ContributeEntity.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/entity/ContributeEntity.java
@@ -1,0 +1,23 @@
+package com.team2._3dinterest.domain.yugyeong.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@Table(name="contribute_table")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContributeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private int post_id;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id", referencedColumnName = "post_id", nullable = false)
+    private PostEntity parent_id;
+}

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/entity/DownloadEntity.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/entity/DownloadEntity.java
@@ -15,7 +15,8 @@ public class DownloadEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    private String user_id;
+    @Column(name="user_id")
+    private String userId;
 
     @ManyToOne
     @JoinColumn(name = "post_id", nullable = false)

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/entity/DownloadEntity.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/entity/DownloadEntity.java
@@ -19,6 +19,6 @@ public class DownloadEntity {
     private String userId;
 
     @ManyToOne
-    @JoinColumn(name = "post_id", nullable = false)
+    @JoinColumn(name = "post_id", referencedColumnName = "post_id", nullable = false)
     private PostEntity postId;
 }

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/postlist/controller/PostListController.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/postlist/controller/PostListController.java
@@ -5,7 +5,6 @@ import com.team2._3dinterest.domain.yugyeong.postlist.service.PostListService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -15,7 +14,7 @@ public class PostListController {
     private final PostListService postListService;
 
     @GetMapping
-    public ResponseEntity<List<PostEntity>> postlist() throws IOException {
+    public ResponseEntity<List<PostEntity>> postlist() {
         return postListService.postlist(); // 성공, 200 OK 생성
     }
 }

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/ContributeRepository.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/ContributeRepository.java
@@ -1,0 +1,9 @@
+package com.team2._3dinterest.domain.yugyeong.repository;
+
+import com.team2._3dinterest.domain.yugyeong.entity.ContributeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContributeRepository extends JpaRepository<ContributeEntity, Integer> {
+}

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/DownloadRepository.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/DownloadRepository.java
@@ -3,7 +3,9 @@ package com.team2._3dinterest.domain.yugyeong.repository;
 import com.team2._3dinterest.domain.yugyeong.entity.DownloadEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface DownloadRepository extends JpaRepository<DownloadEntity, Integer> {
+    List<DownloadEntity> findByUserId(String userId); // contribute에서 download_table의 userId 조회
 }

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/PostRepository.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/PostRepository.java
@@ -8,5 +8,4 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Integer> {
     PostEntity findByPostId(int postId);    // download에서 post_table의 postId 조회
-    List<PostEntity> findAll();  // 모든 게시물 조회
 }

--- a/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/PostRepository.java
+++ b/src/main/java/com/team2/_3dinterest/domain/yugyeong/repository/PostRepository.java
@@ -3,7 +3,6 @@ package com.team2._3dinterest.domain.yugyeong.repository;
 import com.team2._3dinterest.domain.yugyeong.entity.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Integer> {


### PR DESCRIPTION
### 컨트리뷰트 기능 정의

- 사용자(user_id)의 다운로드 기록(download_history_table)을 가져온다.
- 그 중 컨트리뷰트할 게시물(post_id)에 대한 상세정보(PostEntity)를 return한다.
- 원작(parent_id)에 대한 새로운 게시물(post_id)을 업로드(upload)한다.
- 부모 게시물(parent_id)과  자식 게시물(post_id)에 대한 컨트리뷰트를 기록(contribute_table)한다.

→ 새로운 API 두 개 필요

1. **다운로드 기록 가져오기**
    
    매개변수: user_id
    
    download_history_table에서 user_id에 해당하는 게시물 목록을 조회하여 대한 다운로드 기록을 가져온다.
    
    download_history_table에서 일치하는 user_id를 찾아 해당 post_id를 가져온다.
    
    download_history_table의 post_id와 post_table의 post_id를 비교해서 해당 post_id의 나머지 디테일을 가져온다.
    
    해당 post_id에 대한 PostEntity를 객체 배열로 보내서 게시글에 대한 상세정보를 보낸다. (post_id, user_id, title, model_url, image_url, tag_a, tag_b, tag_c, tag_d, upload_date, like_cnt)
    
2. **파일 업로드**
    
    업로드 API 재사용
    

1. **컨트리뷰트 기록**
    
    매개변수: post_id, parent_id
    
    post_id= 방금 업로드한 post_id,
    parent_id=부모 게시글의 post_id
    
    컨트리뷰트 테이블에 기록한다.
    

### 주요 변경사항

**Entity**

- ContributeEntity
    
    Contribute를 위한 contribute_table과 1대1 매핑되는 Entity이다.
    parent_id는 PostEntity의 post_id를 참조하는 외래키이다.
    

**Repository**

- ContributeRepository
    
    Contribute를 위한 기본적인 Repository이다.
    

**Controller**

- ContributeListController
    
    Contribute 기능에서 사용자(user_id)의 게시물 목록을 가져와 다운로드 기록을 List 형태로 반환하는 Controller이다. GET 요청의 API이다.
    
- ContributeRecordController
    
    Contribute 기능에서 컨트리뷰트 기록을 하는 Controller이다. 반환값은 없으며, POST 요청의 API이다.
    

**Service**

- ContributeListService
    
    Contribute 기능 중 게시물 조회 및 다운로드 기록을 반환을 하는 Service이다.
    
- ContributeRecordService
    
    Contribute 기능 중 컨트리뷰트 기록을 남기는 Service이다.
    

### 추가 변경사항

- **DownloadEntity**
    
    repository를 통해 db의 user_id를 조회할 때, db와 entity의 user_id의 이름 혼선 방지를 위해 userId로 변경
    
- **DownloadRepository**
    
    ContributeList에서 DownloadEntity의 user_id를 조회하여 List 형태로 반환하는 findByUserId 추가
    
- **PostRepository**
    
    모든 게시물을 조회하는 findAll 함수는 따로 구현하지 않아도 제공된다.
    
- **DownloadEntity**
    
    현재 Dto를 Entity로 변환하는 toEntity를 사용하지 않고 Service에서 build하고 있다.
    원래는 ResponseDto를 만들어 그쪽에서 변환하도록 하려 했는데, ResponseDto의 필요성이 없어져서 Service에서 자체적으로 builder를 통해 변환한다.
    

현재 사용자가 업로드할 당시의 파일 이름을 저장하지 않고 있다. 필요하다면 추후 original_name 추가를 고려한다.